### PR TITLE
invoices can't be updated in update! method

### DIFF
--- a/lib/rspreedly/subscriber.rb
+++ b/lib/rspreedly/subscriber.rb
@@ -105,7 +105,7 @@ module RSpreedly
     # Update a Subscriber (more)
     # PUT /api/v4/[short site name]/subscribers/[subscriber id].xml
     def update!
-      !! api_request(:put, "/subscribers/#{self.customer_id}.xml", :body => self.to_xml(:exclude => [:customer_id]))
+      !! api_request(:put, "/subscribers/#{self.customer_id}.xml", :body => self.to_xml(:exclude => [:customer_id, :invoices]))
     end
 
     def update


### PR DESCRIPTION
When calling the Spreedly API, you can't send the invoices when PUTting to /subscribers/customer_id.xml.
You instead get back the error "This API call does not allow adjusting the following attributes [ invoices ]."

This affects the update! method of RSpreedly::Subscriber, as seen in this sample code.

``` ruby
rs = RSpreedly::Subscriber.new(
  :customer_id => "12345678", 
  :email => "test@example.com",
  :screen_name => "test"
)
rs.save
rs_reload = RSpreedly::Subscriber.find("12345678")
result = rs_reload.update! # Raises RSpreedly::Error::Forbidden: This API call does not allow adjusting the following attributes [ invoices ].
result # => nil
result = rs_reload.save
result # => nil
rs_reload.errors # => ["This API call does not allow adjusting the following attributes [ invoices ]."]
```

The included commit simply prevents the invoices from being sent in the update! method, which lets you save subscribers again.

I'm not aware, however, if this restriction on sending invoices affects any other API calls. I'm also not sure if this affects any of your tests as the HTTP requests are mocked out.
