### PR TITLE
should not send invoices all of the time for subscribers

### DIFF
--- a/lib/rspreedly/subscriber.rb
+++ b/lib/rspreedly/subscriber.rb
@@ -105,7 +105,7 @@ module RSpreedly
     # Update a Subscriber (more)
     # PUT /api/v4/[short site name]/subscribers/[subscriber id].xml
     def update!
-      !! api_request(:put, "/subscribers/#{self.customer_id}.xml", :body => self.to_xml(:exclude => [:customer_id, :invoices]))
+      !! api_request(:put, "/subscribers/#{self.customer_id}.xml", :body => self.to_xml(:exclude => [:customer_id]))
     end
 
     def update
@@ -193,7 +193,8 @@ module RSpreedly
         :grace_until,  :in_grace_period,            :lifetime_subscription,
         :on_trial,     :ready_to_renew,             :recurring,
         :store_credit, :store_credit_currency_code, :subscription_plan_name,
-        :token,        :updated_at,                 :ready_to_renew_since
+        :token,        :updated_at,                 :ready_to_renew_since,
+        :invoices
       ]
 
       opts[:exclude] ||= []


### PR DESCRIPTION
This was the same problem as before (pull request 10), we should be ignoring the invoices element of a subscriber element more generally. So I exclude them more generally in the to_xml method.

This fixes

``` ruby
invoice = Invoice.new(:subscription_plan_id => 1234, :subscriber => existing_subscriber)
invoice.create! # => Raises the same error from pull request 10
```

And again, there's no way to test except against the live site, so there are no added tests.
